### PR TITLE
feat: add CLA check to workflows

### DIFF
--- a/.github/workflows/cla-check.yaml
+++ b/.github/workflows/cla-check.yaml
@@ -1,0 +1,11 @@
+name: Check if CLA is signed
+on:
+    pull_request:
+
+jobs:
+  cla-check:
+    name: Check if CLA is signed
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if CLA signed
+        uses: canonical/has-signed-canonical-cla@v2


### PR DESCRIPTION
As part of Canonical CLA's process, we add a CLA check workflow to check that user pushing or performing a PR has signed a CLA.