### PR TITLE
chore: add code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @canonical/device-management-telemetry


### PR DESCRIPTION
Adds CODEOWNERS file to automatically request team reviews on all PRs. This eliminates the need to manually post review requests in Mattermost - GitHub will now handle review routing directly.
